### PR TITLE
Remove project name from yaml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,6 @@ jobs:
         with:
           cache-env: true
           environment-file: environment.yml
-          environment-name: py_app_base
 
       - name: check conda env
         run: |

--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 # Developer notes
 Don't forget to update the name of the project:
 - In README.md, replace {Project Name} with the correct name
-- In [environment.yml](environment.yml), replace `py_app_base` with the correct name
-- In [test.yml](.github/workflows/test.yml), replance `py_app_base` with the correct name
 - Fix the links for the github workflow badges on top of README.md
 
 
@@ -15,7 +13,7 @@ The python development environment for the project is based on conda. If you don
 For the first use, the conda environment can be created using:
 
 ```bash
-$ conda env create -f environment.yml
+$ conda env create -n -f{Project Name} environment.yml
 ```
 
 ### Activating conda environment

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,3 @@
-name: py_app_base
 channels:
   - conda-forge
   - defaults
@@ -8,3 +7,4 @@ dependencies:
   - black
   - flake8
   - python=3.10
+  # add project dependencies below


### PR DESCRIPTION
The experience shows keeping the environment name outside the yml file makes life easier, especially when dealing with various CI/CD tools.